### PR TITLE
Prevent uncaught exceptions in a partition worker from killing all outbox processing

### DIFF
--- a/adapter-out-executor/src/main/kotlin/de/chrgroth/quarkus/outbox/adapter/out/executor/CoroutinesAdapter.kt
+++ b/adapter-out-executor/src/main/kotlin/de/chrgroth/quarkus/outbox/adapter/out/executor/CoroutinesAdapter.kt
@@ -6,6 +6,7 @@ import jakarta.annotation.PreDestroy
 import jakarta.enterprise.context.ApplicationScoped
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.Channel
 import java.util.concurrent.ConcurrentHashMap
@@ -14,7 +15,7 @@ import java.util.concurrent.ConcurrentHashMap
 @Suppress("Unused")
 class CoroutinesAdapter : CoroutinesPort {
 
-  private val scope = CoroutineScope(Dispatchers.IO)
+  private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
   private val channels: MutableMap<String, Channel<Unit>> = ConcurrentHashMap()
 
   override fun getScope() = scope

--- a/adapter-out-executor/src/test/kotlin/de/chrgroth/quarkus/outbox/adapter/out/executor/CoroutinesAdapterTests.kt
+++ b/adapter-out-executor/src/test/kotlin/de/chrgroth/quarkus/outbox/adapter/out/executor/CoroutinesAdapterTests.kt
@@ -54,6 +54,17 @@ class CoroutinesAdapterTests {
   }
 
   @Test
+  fun `exception in one child coroutine does not cancel the scope`() {
+    runBlocking {
+      adapter.getScope().launch {
+        throw IllegalStateException("boom")
+      }.join()
+
+      assertThat(adapter.getScope().isActive).isTrue()
+    }
+  }
+
+  @Test
   fun `wakeUp for one partition does not signal another partition`() {
     runBlocking {
       adapter.signal(partitionA)

--- a/docs/releasenotes/snippets/issue-44-20260723-0453-bugfix.md
+++ b/docs/releasenotes/snippets/issue-44-20260723-0453-bugfix.md
@@ -1,0 +1,1 @@
+* issue-44-20260723-0453: Fixed a bug where an unexpected error while dispatching an outbox task (e.g. a database connection issue) could silently stop all outbox processing for every partition until the application was restarted.

--- a/docs/releasenotes/snippets/issue-44-20260723-0453-bugfix.md
+++ b/docs/releasenotes/snippets/issue-44-20260723-0453-bugfix.md
@@ -1,1 +1,2 @@
 * issue-44-20260723-0453: Fixed a bug where an unexpected error while dispatching an outbox task (e.g. a database connection issue) could silently stop all outbox processing for every partition until the application was restarted.
+* issue-44-20260723-0453: An unexpected error while dispatching an outbox task is now treated as a regular failure, so the task's retry count is incremented and it is retried or archived as failed instead of getting stuck.

--- a/domain-impl/src/main/kotlin/de/chrgroth/quarkus/outbox/domain/OutboxControllerAdapter.kt
+++ b/domain-impl/src/main/kotlin/de/chrgroth/quarkus/outbox/domain/OutboxControllerAdapter.kt
@@ -102,6 +102,7 @@ class OutboxControllerAdapter(
 
   fun resetStaleProcessingTasks() = taskPort.resetStaleProcessing()
 
+  @Suppress("TooGenericExceptionCaught")
   fun dispatchTask(partition: ApplicationOutboxPartition): Boolean {
     val partitionInfo = partitionPort.findOrCreate(partition)
     if (partitionInfo.status == OutboxPartitionStatus.PAUSED) {
@@ -111,8 +112,15 @@ class OutboxControllerAdapter(
     val task = taskPort.claim(partition)
       ?: return false
 
-    val event = applicationOutboxDispatcher.deserialize(partition, task.eventType, task.payload)
-    return when (val result = applicationOutboxDispatcher.dispatch(event)) {
+    val dispatchResult = try {
+      val event = applicationOutboxDispatcher.deserialize(partition, task.eventType, task.payload)
+      applicationOutboxDispatcher.dispatch(event)
+    } catch (e: Exception) {
+      logger.error(e) { "Unexpected error dispatching task ${task.id} for partition ${partition.key}, treating as failed" }
+      DispatchResult.Failed(e.message ?: e.toString(), e)
+    }
+
+    return when (dispatchResult) {
       is DispatchResult.Success -> {
         complete(task, partition)
         processedCounters.getOrPut("${partition.key}:${task.priority.name}") {
@@ -122,11 +130,11 @@ class OutboxControllerAdapter(
       }
 
       is DispatchResult.Paused -> {
-        val pausedUntil = result.pausedUntil
-        partitionPort.pause(partition, result.reason, pausedUntil)
+        val pausedUntil = dispatchResult.pausedUntil
+        partitionPort.pause(partition, dispatchResult.reason, pausedUntil)
         taskPort.reschedule(task, pausedUntil ?: Instant.now())
         taskRescheduledEvents.fireAsync(OutboxTaskRescheduledEvent(partition, task.eventType))
-        pausePartition(partition, result.reason, pausedUntil)
+        pausePartition(partition, dispatchResult.reason, pausedUntil)
         pausedCounters.getOrPut("${partition.key}:${task.priority.name}") {
           meterRegistry.counter("outbox.tasks.paused", "partition", partition.key, "priority", task.priority.name)
         }.increment()
@@ -144,11 +152,11 @@ class OutboxControllerAdapter(
       is DispatchResult.Failed -> {
         val newAttempts = task.attempts + 1
         if (newAttempts >= retryPolicy.maxAttempts) {
-          fail(task, result.message, null, partition)
+          fail(task, dispatchResult.message, null, partition)
         } else {
           val delay = retryPolicy.backoff.getOrElse(task.attempts) { retryPolicy.backoff.last() }
           val nextRetryAt = Instant.now().plus(delay)
-          fail(task, result.message, nextRetryAt, partition)
+          fail(task, dispatchResult.message, nextRetryAt, partition)
         }
         failedCounters.getOrPut("${partition.key}:${task.priority.name}") {
           meterRegistry.counter("outbox.tasks.failed", "partition", partition.key, "priority", task.priority.name)

--- a/domain-impl/src/main/kotlin/de/chrgroth/quarkus/outbox/domain/startup/PartitionWorkerStarter.kt
+++ b/domain-impl/src/main/kotlin/de/chrgroth/quarkus/outbox/domain/startup/PartitionWorkerStarter.kt
@@ -10,6 +10,7 @@ import io.quarkus.runtime.StartupEvent
 import jakarta.annotation.Priority
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.enterprise.event.Observes
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
@@ -70,21 +71,28 @@ class PartitionWorkerStarter(
     coroutinesPort.signal(partition)
   }
 
+  @Suppress("TooGenericExceptionCaught")
   private fun startPartitionWorker(partition: ApplicationOutboxPartition) {
     logger.info { "Starting partition worker for ${partition.key}" }
     coroutinesPort.getScope().launch {
       val throttleInterval = partition.throttleInterval
       while (isActive) {
-        coroutinesPort.waitOnSignal(partition)
+        try {
+          coroutinesPort.waitOnSignal(partition)
 
-        var processed: Boolean
-        do {
-          processed = executionAdapter.dispatchTask(partition)
+          var processed: Boolean
+          do {
+            processed = executionAdapter.dispatchTask(partition)
 
-          if (processed && throttleInterval != null) {
-            delay(throttleInterval.toMillis())
-          }
-        } while (processed && isActive)
+            if (processed && throttleInterval != null) {
+              delay(throttleInterval.toMillis())
+            }
+          } while (processed && isActive)
+        } catch (e: CancellationException) {
+          throw e
+        } catch (e: Exception) {
+          logger.error(e) { "Unexpected error in partition worker for ${partition.key}, continuing" }
+        }
       }
     }
   }

--- a/domain-impl/src/test/kotlin/de/chrgroth/quarkus/outbox/domain/OutboxControllerAdapterTests.kt
+++ b/domain-impl/src/test/kotlin/de/chrgroth/quarkus/outbox/domain/OutboxControllerAdapterTests.kt
@@ -320,6 +320,40 @@ class OutboxControllerAdapterTests {
   }
 
   @Test
+  fun `dispatchTask treats exception from dispatch as failed and schedules retry`() {
+    val task = task(attempts = 0)
+    every { partitionPort.findOrCreate(partition) } returns activePartitionInfo()
+    every { taskPort.claim(partition) } returns task
+    stubDeserialize()
+    every { applicationOutboxDispatcher.dispatch(any()) } throws IllegalStateException("boom")
+    val capturedNextRetryAt = mutableListOf<Instant>()
+    every { taskPort.scheduleRetry(task, any(), capture(capturedNextRetryAt)) } just runs
+
+    assertThat(adapter.dispatchTask(partition)).isTrue()
+    assertThat(capturedNextRetryAt.first()).isNotNull()
+    assertThat(meterRegistry.counter("outbox.tasks.failed", "partition", partition.key, "priority", OutboxEventPriority.MEDIUM.name).count()).isEqualTo(1.0)
+    verify { taskRetryScheduledEvents.fireAsync(OutboxTaskRetryScheduledEvent(partition, task.eventType)) }
+  }
+
+  @Test
+  fun `dispatchTask treats exception from deserialize as failed and archives after maxAttempts`() {
+    val task = task(attempts = 4)
+    every { partitionPort.findOrCreate(partition) } returns activePartitionInfo()
+    every { taskPort.claim(partition) } returns task
+    every { applicationOutboxDispatcher.deserialize(any(), any(), any()) } throws IllegalStateException("boom")
+    every { archivePort.appendFailed(task, "boom") } just runs
+    every { taskPort.delete(task) } just runs
+    stubDecrementEventTypeCount()
+
+    assertThat(adapter.dispatchTask(partition)).isTrue()
+    verify { archivePort.appendFailed(task, "boom") }
+    verify { taskPort.delete(task) }
+    verify(exactly = 0) { applicationOutboxDispatcher.dispatch(any()) }
+    assertThat(meterRegistry.counter("outbox.tasks.failed", "partition", partition.key, "priority", OutboxEventPriority.MEDIUM.name).count()).isEqualTo(1.0)
+    verify { taskFailedEvents.fireAsync(OutboxTaskFailedEvent(partition, task.eventType)) }
+  }
+
+  @Test
   fun `dispatchTask uses backoff list correctly for retry delays`() {
     val task = task(attempts = 1)
     every { partitionPort.findOrCreate(partition) } returns activePartitionInfo()

--- a/domain-impl/src/test/kotlin/de/chrgroth/quarkus/outbox/domain/startup/PartitionWorkerStarterTests.kt
+++ b/domain-impl/src/test/kotlin/de/chrgroth/quarkus/outbox/domain/startup/PartitionWorkerStarterTests.kt
@@ -7,6 +7,7 @@ import de.chrgroth.quarkus.outbox.domain.OutboxPartitionInfo
 import de.chrgroth.quarkus.outbox.domain.OutboxPartitionStatus
 import de.chrgroth.quarkus.outbox.domain.port.out.CoroutinesPort
 import de.chrgroth.quarkus.outbox.domain.port.out.PartitionRepositoryPort
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
@@ -16,10 +17,15 @@ import io.quarkus.runtime.StartupEvent
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import java.time.Instant
+import java.util.concurrent.atomic.AtomicInteger
 
 class PartitionWorkerStarterTests {
 
@@ -166,5 +172,39 @@ class PartitionWorkerStarterTests {
     recovery.onStart(startupEvent)
 
     assertThat(activationOrder).containsExactly("reset", "activate")
+  }
+
+  @Test
+  fun `partition worker survives exception from dispatchTask and waits for next signal`() {
+    every { executionAdapter.resetStaleProcessingTasks() } just runs
+    every { application.getAllPartitions() } returns listOf(partition)
+    every { partitionPort.findOrCreate(partition) } returns OutboxPartitionInfo(
+      key = partition.key,
+      status = OutboxPartitionStatus.ACTIVE,
+      statusReason = null,
+      pausedUntil = null,
+    )
+    every { executionAdapter.activatePartition(partition) } just runs
+
+    val waitCount = AtomicInteger(0)
+    coEvery { coroutinesPort.waitOnSignal(partition) } answers { waitCount.incrementAndGet(); Unit }
+
+    val dispatchCount = AtomicInteger(0)
+    every { executionAdapter.dispatchTask(partition) } answers {
+      if (dispatchCount.getAndIncrement() == 0) throw IllegalStateException("boom") else false
+    }
+
+    recovery.onStart(startupEvent)
+
+    runBlocking {
+      withTimeout(2000) {
+        while (waitCount.get() < 2) {
+          delay(10)
+        }
+      }
+    }
+
+    assertThat(waitCount.get()).isGreaterThanOrEqualTo(2)
+    assertThat(testScope.isActive).isTrue()
   }
 }


### PR DESCRIPTION
## Summary

Fixes a bug where an unhandled exception thrown from inside a partition worker's dispatch loop (e.g. a MongoDB connection error during `taskPort.claim()` or `deserialize()`) could silently cancel the shared coroutine scope, permanently stopping outbox processing for *all* partitions until the process was restarted.

- `CoroutinesAdapter` now uses a `SupervisorJob()` for its shared scope, so an exception in one partition's coroutine no longer cancels its siblings.
- `PartitionWorkerStarter.startPartitionWorker()` now wraps the worker loop body in a try/catch that logs unexpected errors and continues waiting for the next signal, instead of letting the exception kill the loop.

Added tests covering both changes.

Closes #44.

🤖 Generated with [Claude Code](https://claude.ai/code)