### PR TITLE
Fix: re-signal partition worker when a failed task's retry is scheduled

### DIFF
--- a/adapter-out-persistence-mongodb/src/main/kotlin/de/chrgroth/quarkus/outbox/adapter/out/mongodb/TaskRepositoryAdapter.kt
+++ b/adapter-out-persistence-mongodb/src/main/kotlin/de/chrgroth/quarkus/outbox/adapter/out/mongodb/TaskRepositoryAdapter.kt
@@ -132,6 +132,17 @@ class TaskRepositoryAdapter : TaskRepositoryPort {
     }
   }
 
+  override fun findEarliestPendingRetryAt(partition: ApplicationOutboxPartition): Instant? =
+    metricsRecorder.timed("outbox.task.findEarliestPendingRetryAt") {
+      repository.mongoCollection().find(
+        Filters.and(
+          Filters.eq("partition", partition.key),
+          Filters.eq("status", OutboxTaskStatus.PENDING.name),
+          Filters.ne("nextRetryAt", null),
+        ),
+      ).sort(Sorts.ascending("nextRetryAt")).first()
+    }?.nextRetryAt
+
   override fun resetStaleProcessing() {
     val now = Instant.now()
     val result = metricsRecorder.timed("outbox.task.resetStaleProcessing") {

--- a/docs/releasenotes/snippets/issue-45-20260723-0628-bugfix.md
+++ b/docs/releasenotes/snippets/issue-45-20260723-0628-bugfix.md
@@ -1,0 +1,2 @@
+* issue-45-20260723-0628: Fixed a bug where a failed task's scheduled retry never woke up its partition worker, so a task with a fixed/singleton deduplication key could get permanently stuck after a single transient failure until the application was restarted or an unrelated task happened to be enqueued on the same partition.
+* issue-45-20260723-0628: The partition worker is now also re-armed for any still-pending retries when the application starts up, closing the same gap across restarts.

--- a/domain-impl/src/main/kotlin/de/chrgroth/quarkus/outbox/domain/OutboxControllerAdapter.kt
+++ b/domain-impl/src/main/kotlin/de/chrgroth/quarkus/outbox/domain/OutboxControllerAdapter.kt
@@ -79,6 +79,11 @@ class OutboxControllerAdapter(
     partitionActivatedEvents.fireAsync(OutboxPartitionActivatedEvent(partition))
   }
 
+  fun scheduleRetryWakeupIfNeeded(partition: ApplicationOutboxPartition) {
+    val nextRetryAt = taskPort.findEarliestPendingRetryAt(partition) ?: return
+    scheduleRetrySignal(partition, nextRetryAt)
+  }
+
   private fun pausePartition(partition: ApplicationOutboxPartition, reason: String?, pausedUntil: Instant?) {
     getOrCreatePartitionStatusGauge(partition).set(0)
     partitionPausedEvents.fireAsync(OutboxPartitionPausedEvent(partition, reason, pausedUntil))
@@ -190,6 +195,15 @@ class OutboxControllerAdapter(
     } else {
       taskPort.scheduleRetry(task, error, nextRetryAt)
       taskRetryScheduledEvents.fireAsync(OutboxTaskRetryScheduledEvent(partition, task.eventType))
+      scheduleRetrySignal(partition, nextRetryAt)
+    }
+  }
+
+  private fun scheduleRetrySignal(partition: ApplicationOutboxPartition, nextRetryAt: Instant) {
+    val delayMs = maxOf(0L, nextRetryAt.toEpochMilli() - Instant.now().toEpochMilli())
+    coroutinesPort.getScope().launch {
+      delay(delayMs)
+      coroutinesPort.signal(partition)
     }
   }
 

--- a/domain-impl/src/main/kotlin/de/chrgroth/quarkus/outbox/domain/port/out/TaskRepositoryPort.kt
+++ b/domain-impl/src/main/kotlin/de/chrgroth/quarkus/outbox/domain/port/out/TaskRepositoryPort.kt
@@ -12,6 +12,7 @@ interface TaskRepositoryPort {
   fun enqueue(partition: ApplicationOutboxPartition, event: ApplicationOutboxEvent, payload: String, priority: OutboxEventPriority): Boolean
   fun scheduleRetry(task: OutboxTask, error: String, nextRetryAt: Instant)
   fun reschedule(task: OutboxTask, nextRetryAt: Instant)
+  fun findEarliestPendingRetryAt(partition: ApplicationOutboxPartition): Instant?
   fun resetStaleProcessing()
   fun countByPartition(partition: ApplicationOutboxPartition): Long
   fun countByEventType(partitionKey: String): Map<String, Long>

--- a/domain-impl/src/main/kotlin/de/chrgroth/quarkus/outbox/domain/startup/PartitionWorkerStarter.kt
+++ b/domain-impl/src/main/kotlin/de/chrgroth/quarkus/outbox/domain/startup/PartitionWorkerStarter.kt
@@ -68,6 +68,7 @@ class PartitionWorkerStarter(
 
   private fun recoverActive(partition: ApplicationOutboxPartition) {
     executionAdapter.activatePartition(partition)
+    executionAdapter.scheduleRetryWakeupIfNeeded(partition)
     coroutinesPort.signal(partition)
   }
 

--- a/domain-impl/src/test/kotlin/de/chrgroth/quarkus/outbox/domain/OutboxControllerAdapterTests.kt
+++ b/domain-impl/src/test/kotlin/de/chrgroth/quarkus/outbox/domain/OutboxControllerAdapterTests.kt
@@ -438,6 +438,37 @@ class OutboxControllerAdapterTests {
     assertThat(meterRegistry.counter("outbox.archive.added").count()).isEqualTo(0.0)
   }
 
+  // --- retry re-signal ---
+
+  @Test
+  fun `fail with retry schedules a delayed re-signal for the partition`() {
+    val task = task()
+    every { taskPort.scheduleRetry(task, any(), any()) } just runs
+
+    adapter.fail(task, "transient error", Instant.now(), partition)
+
+    verify { taskPort.scheduleRetry(task, "transient error", any()) }
+    verify(timeout = 2000) { coroutinesPort.signal(partition) }
+  }
+
+  @Test
+  fun `scheduleRetryWakeupIfNeeded does nothing when no pending retry exists`() {
+    every { taskPort.findEarliestPendingRetryAt(partition) } returns null
+
+    adapter.scheduleRetryWakeupIfNeeded(partition)
+
+    verify(exactly = 0) { coroutinesPort.getScope() }
+  }
+
+  @Test
+  fun `scheduleRetryWakeupIfNeeded schedules a delayed signal for the earliest pending retry`() {
+    every { taskPort.findEarliestPendingRetryAt(partition) } returns Instant.now()
+
+    adapter.scheduleRetryWakeupIfNeeded(partition)
+
+    verify(timeout = 2000) { coroutinesPort.signal(partition) }
+  }
+
   @Test
   fun `paused task blocks all subsequent tasks in the partition`() {
     val task = task()

--- a/domain-impl/src/test/kotlin/de/chrgroth/quarkus/outbox/domain/startup/PartitionWorkerStarterTests.kt
+++ b/domain-impl/src/test/kotlin/de/chrgroth/quarkus/outbox/domain/startup/PartitionWorkerStarterTests.kt
@@ -71,10 +71,12 @@ class PartitionWorkerStarterTests {
       pausedUntil = null,
     )
     every { executionAdapter.activatePartition(partition) } just runs
+    every { executionAdapter.scheduleRetryWakeupIfNeeded(partition) } just runs
 
     recovery.onStart(startupEvent)
 
     verify { executionAdapter.activatePartition(partition) }
+    verify { executionAdapter.scheduleRetryWakeupIfNeeded(partition) }
     verify { coroutinesPort.signal(partition) }
   }
 
@@ -106,10 +108,12 @@ class PartitionWorkerStarterTests {
       pausedUntil = Instant.now().minusSeconds(60),
     )
     every { executionAdapter.activatePartition(partition) } just runs
+    every { executionAdapter.scheduleRetryWakeupIfNeeded(partition) } just runs
 
     recovery.onStart(startupEvent)
 
     verify { executionAdapter.activatePartition(partition) }
+    verify { executionAdapter.scheduleRetryWakeupIfNeeded(partition) }
     verify { coroutinesPort.signal(partition) }
   }
 
@@ -147,11 +151,14 @@ class PartitionWorkerStarterTests {
       pausedUntil = null,
     )
     every { executionAdapter.activatePartition(any()) } just runs
+    every { executionAdapter.scheduleRetryWakeupIfNeeded(any()) } just runs
 
     recovery.onStart(startupEvent)
 
     verify { executionAdapter.activatePartition(partitionA) }
     verify { executionAdapter.activatePartition(partitionB) }
+    verify { executionAdapter.scheduleRetryWakeupIfNeeded(partitionA) }
+    verify { executionAdapter.scheduleRetryWakeupIfNeeded(partitionB) }
     verify { coroutinesPort.signal(partitionA) }
     verify { coroutinesPort.signal(partitionB) }
   }
@@ -168,6 +175,7 @@ class PartitionWorkerStarterTests {
       pausedUntil = null,
     )
     every { executionAdapter.activatePartition(partition) } answers { activationOrder.add("activate") }
+    every { executionAdapter.scheduleRetryWakeupIfNeeded(partition) } just runs
 
     recovery.onStart(startupEvent)
 
@@ -185,6 +193,7 @@ class PartitionWorkerStarterTests {
       pausedUntil = null,
     )
     every { executionAdapter.activatePartition(partition) } just runs
+    every { executionAdapter.scheduleRetryWakeupIfNeeded(partition) } just runs
 
     val waitCount = AtomicInteger(0)
     coEvery { coroutinesPort.waitOnSignal(partition) } answers { waitCount.incrementAndGet(); Unit }


### PR DESCRIPTION
## Summary
- Fixes a bug where a failed task's scheduled retry never re-signaled the partition worker, causing a permanent silent stall for event types using a fixed/singleton deduplication key.
- Mirrors the existing `Paused` branch's delayed re-signal behavior for the `Failed`/retry path.
- Also re-arms the retry wakeup timer on application startup for any still-pending retries, closing the same gap across restarts.

Closes #45.

## Test plan
- [x] Added unit tests for the new re-signal behavior in `OutboxControllerAdapterTests`
- [x] Updated `PartitionWorkerStarterTests` to cover the new startup re-arm call
- [x] `./gradlew build` passes locally

Generated with [Claude Code](https://claude.ai/code)